### PR TITLE
Fixed bug in Sobel filter example

### DIFF
--- a/examples/sobelfilter/xf_config_params.h
+++ b/examples/sobelfilter/xf_config_params.h
@@ -42,4 +42,4 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define GRAY 1
 #define RGBA 0
-//#define XF_USE_URAM false
+#define XF_USE_URAM false


### PR DESCRIPTION
Sobel filter example does not compile due to undefined XF_USE_URAM.  Upon inspection the XF_USE_URAM definition is commented out in the xf_config_params.h file.  This uncomments the XF_USE_URAM definition in the xf_config_params.h file.